### PR TITLE
Support local Nominatim servers

### DIFF
--- a/R/geo_address_lookup.R
+++ b/R/geo_address_lookup.R
@@ -41,12 +41,14 @@ geo_address_lookup <- function(osm_ids,
                                full_results = FALSE,
                                return_addresses = TRUE,
                                verbose = FALSE,
-                               nominatim_server = 'https://nominatim.openstreetmap.org/',
+                               nominatim_server =
+                                 "https://nominatim.openstreetmap.org/",
                                custom_query = list()) {
   # Step 1: Download ----
   # First build the api address. If the passed nominatim_server does not end
   # with a trailing forward-slash, add one
-  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+  if (substr(nominatim_server, nchar(nominatim_server),
+             nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
   api <- paste0(nominatim_server, "lookup?")

--- a/R/geo_address_lookup.R
+++ b/R/geo_address_lookup.R
@@ -41,9 +41,15 @@ geo_address_lookup <- function(osm_ids,
                                full_results = FALSE,
                                return_addresses = TRUE,
                                verbose = FALSE,
+                               nominatim_server = 'https://nominatim.openstreetmap.org/',
                                custom_query = list()) {
   # Step 1: Download ----
-  api <- "https://nominatim.openstreetmap.org/lookup?"
+  # First build the api address. If the passed nominatim_server does not end
+  # with a trailing forward-slash, add one
+  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+    nominatim_server <- paste0(nominatim_server, "/")
+  }
+  api <- paste0(nominatim_server, "lookup?")
 
   # Prepare nodes
   osm_ids <- as.integer(osm_ids)

--- a/R/geo_address_lookup_sf.R
+++ b/R/geo_address_lookup_sf.R
@@ -58,7 +58,8 @@ geo_address_lookup_sf <- function(osm_ids,
                                   full_results = FALSE,
                                   return_addresses = TRUE,
                                   verbose = FALSE,
-                                  nominatim_server = 'https://nominatim.openstreetmap.org/',
+                                  nominatim_server =
+                                    "https://nominatim.openstreetmap.org/",
                                   custom_query = list(),
                                   points_only = TRUE) {
   # First build the api address. If the passed nominatim_server does not end

--- a/R/geo_address_lookup_sf.R
+++ b/R/geo_address_lookup_sf.R
@@ -64,7 +64,8 @@ geo_address_lookup_sf <- function(osm_ids,
                                   points_only = TRUE) {
   # First build the api address. If the passed nominatim_server does not end
   # with a trailing forward-slash, add one
-  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+  if (substr(nominatim_server, nchar(nominatim_server),
+             nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
   api <- paste0(nominatim_server, "lookup?")

--- a/R/geo_address_lookup_sf.R
+++ b/R/geo_address_lookup_sf.R
@@ -58,10 +58,15 @@ geo_address_lookup_sf <- function(osm_ids,
                                   full_results = FALSE,
                                   return_addresses = TRUE,
                                   verbose = FALSE,
+                                  nominatim_server = 'https://nominatim.openstreetmap.org/',
                                   custom_query = list(),
                                   points_only = TRUE) {
-  # Step 1: Download ----
-  api <- "https://nominatim.openstreetmap.org/lookup?"
+  # First build the api address. If the passed nominatim_server does not end
+  # with a trailing forward-slash, add one
+  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+    nominatim_server <- paste0(nominatim_server, "/")
+  }
+  api <- paste0(nominatim_server, "lookup?")
 
   # Prepare nodes
   osm_ids <- as.integer(osm_ids)

--- a/R/geo_lite.R
+++ b/R/geo_lite.R
@@ -17,6 +17,7 @@
 #'    returned. See also `return_addresses`.
 #' @param return_addresses return input addresses with results if `TRUE`.
 #' @param verbose if `TRUE` then detailed logs are output to the console.
+#' @param nominatim_server The URL of the Nominatim server to use. Defaults to https://nominatim.openstreetmap.org/
 #' @param progressbar Logical. If `TRUE` displays a progress bar to indicate
 #'   the progress of the function.
 #' @param custom_query A named list with API-specific parameters to be used

--- a/R/geo_lite.R
+++ b/R/geo_lite.R
@@ -17,7 +17,8 @@
 #'    returned. See also `return_addresses`.
 #' @param return_addresses return input addresses with results if `TRUE`.
 #' @param verbose if `TRUE` then detailed logs are output to the console.
-#' @param nominatim_server The URL of the Nominatim server to use. Defaults to https://nominatim.openstreetmap.org/
+#' @param nominatim_server The URL of the Nominatim server to use.
+#'    Defaults to https://nominatim.openstreetmap.org/
 #' @param progressbar Logical. If `TRUE` displays a progress bar to indicate
 #'   the progress of the function.
 #' @param custom_query A named list with API-specific parameters to be used
@@ -54,7 +55,7 @@ geo_lite <- function(address,
                      full_results = FALSE,
                      return_addresses = TRUE,
                      verbose = FALSE,
-                     nominatim_server = 'https://nominatim.openstreetmap.org/',
+                     nominatim_server = "https://nominatim.openstreetmap.org/",
                      progressbar = TRUE,
                      custom_query = list()) {
   if (limit > 50) {
@@ -114,11 +115,13 @@ geo_lite_single <- function(address,
                             full_results = TRUE,
                             return_addresses = TRUE,
                             verbose = FALSE,
-                            nominatim_server = 'https://nominatim.openstreetmap.org/',
+                            nominatim_server =
+                              "https://nominatim.openstreetmap.org/",
                             custom_query = list()) {
   # First build the api address. If the passed nominatim_server does not end
   # with a trailing forward-slash, add one
-  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+  if (substr(nominatim_server, nchar(nominatim_server),
+             nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
   api <- paste0(nominatim_server, "search.php?q=")

--- a/R/geo_lite.R
+++ b/R/geo_lite.R
@@ -53,6 +53,7 @@ geo_lite <- function(address,
                      full_results = FALSE,
                      return_addresses = TRUE,
                      verbose = FALSE,
+                     nominatim_server = 'https://nominatim.openstreetmap.org/',
                      progressbar = TRUE,
                      custom_query = list()) {
   if (limit > 50) {
@@ -90,6 +91,7 @@ geo_lite <- function(address,
       full_results,
       return_addresses,
       verbose,
+      nominatim_server = nominatim_server,
       custom_query
     )
   })
@@ -118,7 +120,7 @@ geo_lite_single <- function(address,
   if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
-  api <- paste0(nominatim_server, "lookup?")
+  api <- paste0(nominatim_server, "search.php?q=")
 
   # Replace spaces with +
   address2 <- gsub(" ", "+", address)

--- a/R/geo_lite.R
+++ b/R/geo_lite.R
@@ -111,9 +111,14 @@ geo_lite_single <- function(address,
                             full_results = TRUE,
                             return_addresses = TRUE,
                             verbose = FALSE,
+                            nominatim_server = 'https://nominatim.openstreetmap.org/',
                             custom_query = list()) {
-  # Step 1: Download ----
-  api <- "https://nominatim.openstreetmap.org/search?q="
+  # First build the api address. If the passed nominatim_server does not end
+  # with a trailing forward-slash, add one
+  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+    nominatim_server <- paste0(nominatim_server, "/")
+  }
+  api <- paste0(nominatim_server, "lookup?")
 
   # Replace spaces with +
   address2 <- gsub(" ", "+", address)

--- a/R/geo_lite_sf.R
+++ b/R/geo_lite_sf.R
@@ -83,6 +83,7 @@ geo_lite_sf <- function(address,
                         full_results = FALSE,
                         verbose = FALSE,
                         progressbar = TRUE,
+                        nominatim_server = 'https://nominatim.openstreetmap.org/',
                         custom_query = list(),
                         points_only = TRUE) {
   if (limit > 50) {
@@ -121,7 +122,8 @@ geo_lite_sf <- function(address,
       full_results,
       verbose,
       custom_query,
-      points_only
+      points_only,
+      nominatim_server = nominatim_server
     )
   })
 
@@ -154,10 +156,15 @@ geo_lite_sf_single <- function(address,
                                return_addresses = TRUE,
                                full_results = FALSE,
                                verbose = FALSE,
+                               nominatim_server = 'https://nominatim.openstreetmap.org/',
                                custom_query = list(),
                                points_only = TRUE) {
-  # Step 1: Download ----
-  api <- "https://nominatim.openstreetmap.org/search?q="
+  # First build the api address. If the passed nominatim_server does not end
+  # with a trailing forward-slash, add one
+  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+    nominatim_server <- paste0(nominatim_server, "/")
+  }
+  api <- paste0(nominatim_server, "lookup?")
 
   # Replace spaces with +
   address2 <- gsub(" ", "+", address)

--- a/R/geo_lite_sf.R
+++ b/R/geo_lite_sf.R
@@ -164,13 +164,15 @@ geo_lite_sf_single <- function(address,
   if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
-  api <- paste0(nominatim_server, "lookup?")
+  api <- paste0(nominatim_server, "search.php?q=")
 
   # Replace spaces with +
   address2 <- gsub(" ", "+", address)
 
   # Compose url
   url <- paste0(api, address2, "&format=geojson&limit=", limit)
+
+  print(url)
 
   if (full_results) url <- paste0(url, "&addressdetails=1")
   if (!isTRUE(points_only)) url <- paste0(url, "&polygon_geojson=1")

--- a/R/geo_lite_sf.R
+++ b/R/geo_lite_sf.R
@@ -83,7 +83,8 @@ geo_lite_sf <- function(address,
                         full_results = FALSE,
                         verbose = FALSE,
                         progressbar = TRUE,
-                        nominatim_server = 'https://nominatim.openstreetmap.org/',
+                        nominatim_server =
+                          "https://nominatim.openstreetmap.org/",
                         custom_query = list(),
                         points_only = TRUE) {
   if (limit > 50) {
@@ -156,12 +157,14 @@ geo_lite_sf_single <- function(address,
                                return_addresses = TRUE,
                                full_results = FALSE,
                                verbose = FALSE,
-                               nominatim_server = 'https://nominatim.openstreetmap.org/',
+                               nominatim_server =
+                                 "https://nominatim.openstreetmap.org/",
                                custom_query = list(),
                                points_only = TRUE) {
   # First build the api address. If the passed nominatim_server does not end
   # with a trailing forward-slash, add one
-  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+  if (substr(nominatim_server, nchar(nominatim_server),
+             nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
   api <- paste0(nominatim_server, "search.php?q=")

--- a/R/geo_lite_sf.R
+++ b/R/geo_lite_sf.R
@@ -172,8 +172,6 @@ geo_lite_sf_single <- function(address,
   # Compose url
   url <- paste0(api, address2, "&format=geojson&limit=", limit)
 
-  print(url)
-
   if (full_results) url <- paste0(url, "&addressdetails=1")
   if (!isTRUE(points_only)) url <- paste0(url, "&polygon_geojson=1")
 

--- a/R/nominatim_check_access.R
+++ b/R/nominatim_check_access.R
@@ -17,8 +17,13 @@
 #' }
 #' @keywords internal
 #' @export
-nominatim_check_access <- function() {
-  url <- "https://nominatim.openstreetmap.org/status.php?format=json"
+nominatim_check_access <- function(nominatim_server = 'https://nominatim.openstreetmap.org/') {
+  # First build the api address. If the passed nominatim_server does not end
+  # with a trailing forward-slash, add one
+  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+    nominatim_server <- paste0(nominatim_server, "/")
+  }
+  url <- paste0(nominatim_server, "status.php?format=json")
   destfile <- tempfile(fileext = ".json")
 
   api_res <- api_call(url, destfile, TRUE)

--- a/R/nominatim_check_access.R
+++ b/R/nominatim_check_access.R
@@ -17,10 +17,13 @@
 #' }
 #' @keywords internal
 #' @export
-nominatim_check_access <- function(nominatim_server = 'https://nominatim.openstreetmap.org/') {
+nominatim_check_access <- function(
+    nominatim_server = "https://nominatim.openstreetmap.org/"
+) {
   # First build the api address. If the passed nominatim_server does not end
   # with a trailing forward-slash, add one
-  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+  if (substr(nominatim_server, nchar(nominatim_server),
+             nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
   url <- paste0(nominatim_server, "status.php?format=json")

--- a/R/nominatim_check_access.R
+++ b/R/nominatim_check_access.R
@@ -18,7 +18,7 @@
 #' @keywords internal
 #' @export
 nominatim_check_access <- function(
-    nominatim_server = "https://nominatim.openstreetmap.org/"
+  nominatim_server = "https://nominatim.openstreetmap.org/"
 ) {
   # First build the api address. If the passed nominatim_server does not end
   # with a trailing forward-slash, add one

--- a/R/reverse_geo_lite.R
+++ b/R/reverse_geo_lite.R
@@ -173,7 +173,7 @@ reverse_geo_lite_single <- function(lat_cap,
   if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
-  api <- paste0(nominatim_server, "lookup?")
+  api <- paste0(nominatim_server, "reverse?")
 
   # Compose url
   url <- paste0(api, "lat=", lat_cap, "&lon=", long_cap, "&format=json")

--- a/R/reverse_geo_lite.R
+++ b/R/reverse_geo_lite.R
@@ -80,6 +80,7 @@ reverse_geo_lite <- function(lat,
                              full_results = FALSE,
                              return_coords = TRUE,
                              verbose = FALSE,
+                             nominatim_server = 'https://nominatim.openstreetmap.org/',
                              progressbar = TRUE,
                              custom_query = list()) {
   # Check inputs
@@ -137,7 +138,8 @@ reverse_geo_lite <- function(lat,
       full_results,
       return_coords,
       verbose,
-      custom_query
+      custom_query,
+      nominatim_server = nominatim_server
     )
 
     res_single <- dplyr::bind_cols(res_single, rw[, c(1, 2)])
@@ -164,9 +166,14 @@ reverse_geo_lite_single <- function(lat_cap,
                                     full_results = FALSE,
                                     return_coords = TRUE,
                                     verbose = TRUE,
+                                    nominatim_server = 'https://nominatim.openstreetmap.org/',
                                     custom_query = list()) {
-  # Step 1: Download ----
-  api <- "https://nominatim.openstreetmap.org/reverse?"
+  # First build the api address. If the passed nominatim_server does not end
+  # with a trailing forward-slash, add one
+  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+    nominatim_server <- paste0(nominatim_server, "/")
+  }
+  api <- paste0(nominatim_server, "lookup?")
 
   # Compose url
   url <- paste0(api, "lat=", lat_cap, "&lon=", long_cap, "&format=json")

--- a/R/reverse_geo_lite.R
+++ b/R/reverse_geo_lite.R
@@ -80,7 +80,8 @@ reverse_geo_lite <- function(lat,
                              full_results = FALSE,
                              return_coords = TRUE,
                              verbose = FALSE,
-                             nominatim_server = 'https://nominatim.openstreetmap.org/',
+                             nominatim_server =
+                               "https://nominatim.openstreetmap.org/",
                              progressbar = TRUE,
                              custom_query = list()) {
   # Check inputs
@@ -166,11 +167,13 @@ reverse_geo_lite_single <- function(lat_cap,
                                     full_results = FALSE,
                                     return_coords = TRUE,
                                     verbose = TRUE,
-                                    nominatim_server = 'https://nominatim.openstreetmap.org/',
+                                    nominatim_server =
+                                      "https://nominatim.openstreetmap.org/",
                                     custom_query = list()) {
   # First build the api address. If the passed nominatim_server does not end
   # with a trailing forward-slash, add one
-  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+  if (substr(nominatim_server, nchar(nominatim_server),
+             nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
   api <- paste0(nominatim_server, "reverse?")

--- a/R/reverse_geo_lite_sf.R
+++ b/R/reverse_geo_lite_sf.R
@@ -182,7 +182,7 @@ reverse_geo_lite_sf_single <- function(lat_cap,
   if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
-  api <- paste0(nominatim_server, "lookup?")
+  api <- paste0(nominatim_server, "reverse?")
 
   # Compose url
   url <- paste0(api, "lat=", lat_cap, "&lon=", long_cap, "&format=geojson")

--- a/R/reverse_geo_lite_sf.R
+++ b/R/reverse_geo_lite_sf.R
@@ -68,7 +68,8 @@ reverse_geo_lite_sf <- function(lat,
                                 full_results = FALSE,
                                 return_coords = TRUE,
                                 verbose = FALSE,
-                                nominatim_server = 'https://nominatim.openstreetmap.org/',
+                                nominatim_server =
+                                  "https://nominatim.openstreetmap.org/",
                                 progressbar = TRUE,
                                 custom_query = list(),
                                 points_only = TRUE) {
@@ -174,12 +175,14 @@ reverse_geo_lite_sf_single <- function(lat_cap,
                                        full_results = TRUE,
                                        return_coords = TRUE,
                                        verbose = TRUE,
-                                       nominatim_server = 'https://nominatim.openstreetmap.org/',
+                                       nominatim_server =
+                                         "https://nominatim.openstreetmap.org/",
                                        custom_query = list(),
                                        points_only = FALSE) {
   # First build the api address. If the passed nominatim_server does not end
   # with a trailing forward-slash, add one
-  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+  if (substr(nominatim_server, nchar(nominatim_server),
+             nchar(nominatim_server)) != "/") {
     nominatim_server <- paste0(nominatim_server, "/")
   }
   api <- paste0(nominatim_server, "reverse?")

--- a/R/reverse_geo_lite_sf.R
+++ b/R/reverse_geo_lite_sf.R
@@ -68,6 +68,7 @@ reverse_geo_lite_sf <- function(lat,
                                 full_results = FALSE,
                                 return_coords = TRUE,
                                 verbose = FALSE,
+                                nominatim_server = 'https://nominatim.openstreetmap.org/',
                                 progressbar = TRUE,
                                 custom_query = list(),
                                 points_only = TRUE) {
@@ -127,7 +128,8 @@ reverse_geo_lite_sf <- function(lat,
       return_coords,
       verbose,
       custom_query,
-      points_only
+      points_only,
+      nominatim_server = nominatim_server
     )
 
     res_single <- dplyr::bind_cols(res_single, rw[, c(1, 2)])
@@ -172,10 +174,15 @@ reverse_geo_lite_sf_single <- function(lat_cap,
                                        full_results = TRUE,
                                        return_coords = TRUE,
                                        verbose = TRUE,
+                                       nominatim_server = 'https://nominatim.openstreetmap.org/',
                                        custom_query = list(),
                                        points_only = FALSE) {
-  # Step 1: Download ----
-  api <- "https://nominatim.openstreetmap.org/reverse?"
+  # First build the api address. If the passed nominatim_server does not end
+  # with a trailing forward-slash, add one
+  if (substr(nominatim_server, nchar(nominatim_server), nchar(nominatim_server)) != "/") {
+    nominatim_server <- paste0(nominatim_server, "/")
+  }
+  api <- paste0(nominatim_server, "lookup?")
 
   # Compose url
   url <- paste0(api, "lat=", lat_cap, "&lon=", long_cap, "&format=geojson")

--- a/man/geo_address_lookup.Rd
+++ b/man/geo_address_lookup.Rd
@@ -12,6 +12,7 @@ geo_address_lookup(
   full_results = FALSE,
   return_addresses = TRUE,
   verbose = FALSE,
+  nominatim_server = "https://nominatim.openstreetmap.org/",
   custom_query = list()
 )
 }
@@ -34,6 +35,8 @@ returned. See also \code{return_addresses}.}
 \item{return_addresses}{return input addresses with results if \code{TRUE}.}
 
 \item{verbose}{if \code{TRUE} then detailed logs are output to the console.}
+
+\item{nominatim_server}{The URL of the Nominatim server to use. Defaults to https://nominatim.openstreetmap.org/}
 
 \item{custom_query}{A named list with API-specific parameters to be used
 (i.e. \code{list(countrycodes = "US")}). See \strong{Details}.}

--- a/man/geo_address_lookup_sf.Rd
+++ b/man/geo_address_lookup_sf.Rd
@@ -10,6 +10,7 @@ geo_address_lookup_sf(
   full_results = FALSE,
   return_addresses = TRUE,
   verbose = FALSE,
+  nominatim_server = "https://nominatim.openstreetmap.org/",
   custom_query = list(),
   points_only = TRUE
 )
@@ -29,6 +30,8 @@ If \code{FALSE} (default) only address columns are returned. See also
 \item{return_addresses}{return input addresses with results if \code{TRUE}.}
 
 \item{verbose}{if \code{TRUE} then detailed logs are output to the console.}
+
+\item{nominatim_server}{The URL of the Nominatim server to use. Defaults to https://nominatim.openstreetmap.org/}
 
 \item{custom_query}{A named list with API-specific parameters to be used
 (i.e. \code{list(countrycodes = "US")}). See \strong{Details}.}

--- a/man/geo_lite.Rd
+++ b/man/geo_lite.Rd
@@ -12,6 +12,7 @@ geo_lite(
   full_results = FALSE,
   return_addresses = TRUE,
   verbose = FALSE,
+  nominatim_server = "https://nominatim.openstreetmap.org/",
   progressbar = TRUE,
   custom_query = list()
 )
@@ -35,6 +36,8 @@ returned. See also \code{return_addresses}.}
 \item{return_addresses}{return input addresses with results if \code{TRUE}.}
 
 \item{verbose}{if \code{TRUE} then detailed logs are output to the console.}
+
+\item{nominatim_server}{The URL of the Nominatim server to use. Defaults to https://nominatim.openstreetmap.org/}
 
 \item{progressbar}{Logical. If \code{TRUE} displays a progress bar to indicate
 the progress of the function.}

--- a/man/geo_lite_sf.Rd
+++ b/man/geo_lite_sf.Rd
@@ -11,6 +11,7 @@ geo_lite_sf(
   full_results = FALSE,
   verbose = FALSE,
   progressbar = TRUE,
+  nominatim_server = "https://nominatim.openstreetmap.org/",
   custom_query = list(),
   points_only = TRUE
 )
@@ -33,6 +34,8 @@ If \code{FALSE} (default) only address columns are returned. See also
 
 \item{progressbar}{Logical. If \code{TRUE} displays a progress bar to indicate
 the progress of the function.}
+
+\item{nominatim_server}{The URL of the Nominatim server to use. Defaults to https://nominatim.openstreetmap.org/}
 
 \item{custom_query}{A named list with API-specific parameters to be used
 (i.e. \code{list(countrycodes = "US")}). See \strong{Details}.}

--- a/man/nominatim_check_access.Rd
+++ b/man/nominatim_check_access.Rd
@@ -4,7 +4,9 @@
 \alias{nominatim_check_access}
 \title{Check access to Nominatim API}
 \usage{
-nominatim_check_access()
+nominatim_check_access(
+  nominatim_server = "https://nominatim.openstreetmap.org/"
+)
 }
 \value{
 a logical.

--- a/man/reverse_geo_lite.Rd
+++ b/man/reverse_geo_lite.Rd
@@ -11,6 +11,7 @@ reverse_geo_lite(
   full_results = FALSE,
   return_coords = TRUE,
   verbose = FALSE,
+  nominatim_server = "https://nominatim.openstreetmap.org/",
   progressbar = TRUE,
   custom_query = list()
 )
@@ -31,6 +32,8 @@ returned. See also \code{return_addresses}.}
 \item{return_coords}{return input coordinates with results if \code{TRUE}.}
 
 \item{verbose}{if \code{TRUE} then detailed logs are output to the console.}
+
+\item{nominatim_server}{The URL of the Nominatim server to use. Defaults to https://nominatim.openstreetmap.org/}
 
 \item{progressbar}{Logical. If \code{TRUE} displays a progress bar to indicate
 the progress of the function.}

--- a/man/reverse_geo_lite_sf.Rd
+++ b/man/reverse_geo_lite_sf.Rd
@@ -11,6 +11,7 @@ reverse_geo_lite_sf(
   full_results = FALSE,
   return_coords = TRUE,
   verbose = FALSE,
+  nominatim_server = "https://nominatim.openstreetmap.org/",
   progressbar = TRUE,
   custom_query = list(),
   points_only = TRUE
@@ -32,6 +33,8 @@ returned. See also \code{return_addresses}.}
 \item{return_coords}{return input coordinates with results if \code{TRUE}.}
 
 \item{verbose}{if \code{TRUE} then detailed logs are output to the console.}
+
+\item{nominatim_server}{The URL of the Nominatim server to use. Defaults to https://nominatim.openstreetmap.org/}
 
 \item{progressbar}{Logical. If \code{TRUE} displays a progress bar to indicate
 the progress of the function.}


### PR DESCRIPTION
Resolves [issue](https://github.com/dieghernan/nominatimlite/issues/41) #41 to support local Nominatim servers by adding a keyword argument `nominatim_server` to:

- bbox_to_poly
- geo_address_lookup
- geo_address_lookup_sf
- geo_lite
- geo_lite_sf
- reverse_geo_lite
- reverse_geo_lite_sf